### PR TITLE
feat(libuv): parallel spread_the_sweat + libuv GTest suite

### DIFF
--- a/include/psi/sweater/impls/libuv.hpp
+++ b/include/psi/sweater/impls/libuv.hpp
@@ -16,9 +16,11 @@
 
 #include <boost/assert.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <exception>
 #include <future>
+#include <latch>
 #include <type_traits>
 #include <utility>
 
@@ -47,15 +49,101 @@ public:
         return thrd_lite::hardware_concurrency_max;
     }
 
+    /// GCD dispatch_apply / Windows TP equivalent — synchronous parallel loop.
+    /// Chunks via `chunked_spread`, queues each chunk on the libuv thread pool,
+    /// and blocks until all chunks finish. `count_down` runs in the pool work
+    /// callback so this is safe when called from a pool worker; if the bound
+    /// loop is not set or only one chunk is needed, falls back to serial.
     template <typename F>
-    static bool spread_the_sweat( iterations_t const iterations, F && work, iterations_t /*parallelizable_count*/ = 1 ) noexcept
+    bool spread_the_sweat( iterations_t const iterations, F && work, iterations_t /*parallelizable_count*/ = 1 ) noexcept
     {
         static_assert( noexcept( work( iterations_t{ 0 }, iterations ) ), "F must be noexcept" );
-        if ( iterations == 0 )
+
+        if ( PSI_UNLIKELY( iterations == 0 ) )
         {
             return true;
         }
-        work( iterations_t{ 0 }, iterations );
+
+        if ( PSI_UNLIKELY( !loop_ ) )
+        {
+            work( iterations_t{ 0 }, iterations );
+            return true;
+        }
+
+        auto const num_workers{ number_of_workers() };
+        auto const num_chunks { static_cast<iterations_t>(
+            std::min( iterations, static_cast<iterations_t>( 4 * num_workers ) )
+        ) };
+
+        if ( PSI_UNLIKELY( num_chunks <= 1 ) )
+        {
+            work( iterations_t{ 0 }, iterations );
+            return true;
+        }
+
+        struct chunk_ctx
+        {
+            void const   * p_work;
+            iterations_t   start;
+            iterations_t   end;
+            std::latch   * p_latch;
+            void (*invoke)( void const *, iterations_t, iterations_t ) noexcept;
+        };
+        static_assert( std::is_trivially_destructible_v<chunk_ctx> );
+
+        void (*const invoke_fn)( void const *, iterations_t, iterations_t ) noexcept =
+            []( void const * pw, iterations_t s, iterations_t e ) noexcept
+            {
+                ( *static_cast<std::decay_t<F> const *>( pw ) )( s, e );
+            };
+
+        std::latch sync{ static_cast<std::ptrdiff_t>( num_chunks ) };
+
+        chunked_spread const setup{ iterations, num_chunks };
+        for ( iterations_t i{ 0 }; i < num_chunks; ++i )
+        {
+            auto const [start, end]{ setup.chunk_range( static_cast<hardware_concurrency_t>( i ) ) };
+
+            struct req_bundle
+            {
+                chunk_ctx  ctx;
+                uv_work_t  req{};
+            };
+
+            auto * const bundle{ new ( std::nothrow ) req_bundle{
+                chunk_ctx{ &work, start, end, &sync, invoke_fn }
+            } };
+            if ( PSI_UNLIKELY( !bundle ) )
+            {
+                work( start, end );
+                sync.count_down();
+                continue;
+            }
+
+            bundle->req.data = bundle;
+            if ( PSI_UNLIKELY( uv_queue_work(
+                     loop_,
+                     &bundle->req,
+                     []( uv_work_t * const req ) noexcept
+                     {
+                         auto * const self{ static_cast<req_bundle *>( req->data ) };
+                         auto & c{ self->ctx };
+                         c.invoke( c.p_work, c.start, c.end );
+                         c.p_latch->count_down();
+                     },
+                     []( uv_work_t * const req, int /*status*/ ) noexcept
+                     {
+                         delete static_cast<req_bundle *>( req->data );
+                     }
+                 ) != 0 ) )
+            {
+                work( start, end );
+                sync.count_down();
+                delete bundle;
+            }
+        }
+
+        sync.wait();
         return true;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,27 @@ endif()
 CPMAddPackage( "gh:google/googletest@1.15.2" )
 include( GoogleTest )
 
-add_executable( sweater_smoke_test smoke_test.cpp )
-target_link_libraries( sweater_smoke_test PRIVATE GTest::gtest_main psi::sweater )
+function( sweater_add_smoke_test target_name )
+    add_executable( ${target_name} smoke_test.cpp )
+    target_link_libraries( ${target_name} PRIVATE GTest::gtest_main psi::sweater )
+    set_target_properties( ${target_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+    add_test( NAME ${target_name} COMMAND ${target_name} )
+endfunction()
 
-set_target_properties( sweater_smoke_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
-add_test( NAME sweater_smoke_test COMMAND sweater_smoke_test )
+sweater_add_smoke_test( sweater_smoke_test )
+
+# Libuv backend tests — only when libuv headers + library are available.
+find_path( SWEATER_LIBUV_INCLUDE_DIR NAMES uv.h )
+find_library( SWEATER_LIBUV_LIBRARY NAMES uv libuv )
+
+if ( SWEATER_LIBUV_INCLUDE_DIR AND SWEATER_LIBUV_LIBRARY )
+    message( STATUS "sweater: libuv found — building sweater_libuv_test (${SWEATER_LIBUV_LIBRARY})" )
+
+    add_executable( sweater_libuv_test libuv_test.cpp )
+    target_include_directories( sweater_libuv_test PRIVATE "${SWEATER_LIBUV_INCLUDE_DIR}" )
+    target_link_libraries( sweater_libuv_test PRIVATE GTest::gtest_main psi::sweater "${SWEATER_LIBUV_LIBRARY}" )
+    set_target_properties( sweater_libuv_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test" )
+    add_test( NAME sweater_libuv_test COMMAND sweater_libuv_test )
+else()
+    message( STATUS "sweater: libuv not found — skipping sweater_libuv_test" )
+endif()

--- a/test/libuv_test.cpp
+++ b/test/libuv_test.cpp
@@ -1,0 +1,132 @@
+#include <psi/sweater/impls/libuv.hpp>
+#include <psi/sweater/dispatch_tracking.hpp>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+
+namespace
+{
+
+struct loop_guard
+{
+    uv_loop_t loop{};
+    bool      ok{ false };
+
+    loop_guard() noexcept { ok = uv_loop_init( &loop ) == 0; }
+
+    ~loop_guard() noexcept
+    {
+        if ( !ok )
+        {
+            return;
+        }
+        drain();
+        uv_loop_close( &loop );
+    }
+
+    void drain() noexcept
+    {
+        while ( uv_loop_alive( &loop ) )
+        {
+            (void)uv_run( &loop, UV_RUN_ONCE );
+        }
+    }
+
+    [[ nodiscard ]] uv_loop_t * get() noexcept { return ok ? &loop : nullptr; }
+};
+
+} // namespace
+
+TEST( SweaterLibuv, SpreadTheSweat_ParallelChunks )
+{
+    loop_guard runner;
+    ASSERT_TRUE( runner.ok );
+
+    psi::sweater::libuv::shop shop;
+    shop.bind_loop( runner.get() );
+
+    std::atomic<std::uint32_t> sum{ 0 };
+    EXPECT_TRUE( shop.spread_the_sweat(
+        1000,
+        [&]( auto const start, auto const end ) noexcept
+        {
+            for ( auto i{ start }; i < end; ++i )
+            {
+                sum.fetch_add( 1, std::memory_order_relaxed );
+            }
+        }
+    ) );
+    runner.drain();
+    EXPECT_EQ( sum.load(), 1000u );
+}
+
+TEST( SweaterLibuv, SpreadTheSweat_NoLoop_FallsBackSerial )
+{
+    psi::sweater::libuv::shop shop;
+
+    std::atomic<std::uint32_t> sum{ 0 };
+    EXPECT_TRUE( shop.spread_the_sweat(
+        256,
+        [&]( auto const start, auto const end ) noexcept
+        {
+            for ( auto i{ start }; i < end; ++i )
+            {
+                sum.fetch_add( 1, std::memory_order_relaxed );
+            }
+        }
+    ) );
+    EXPECT_EQ( sum.load(), 256u );
+}
+
+TEST( SweaterLibuv, FireWithAfter_RunsWorkAndAfter )
+{
+    loop_guard runner;
+    ASSERT_TRUE( runner.ok );
+
+    psi::sweater::libuv::shop shop;
+    shop.bind_loop( runner.get() );
+
+    std::atomic<bool> work_done{ false };
+    std::atomic<bool> after_done{ false };
+
+    EXPECT_TRUE( shop.fire_with_after(
+        [&]() noexcept { work_done.store( true, std::memory_order_release ); },
+        [&]() noexcept { after_done.store( true, std::memory_order_release ); }
+    ) );
+
+    auto const deadline{ std::chrono::steady_clock::now() + std::chrono::seconds{ 5 } };
+    while ( !after_done.load( std::memory_order_acquire ) && std::chrono::steady_clock::now() < deadline )
+    {
+        (void)uv_run( runner.get(), UV_RUN_ONCE );
+    }
+
+    EXPECT_TRUE( work_done.load( std::memory_order_acquire ) );
+    EXPECT_TRUE( after_done.load( std::memory_order_acquire ) );
+    EXPECT_EQ( psi::sweater::detail::in_flight_count(), 0u );
+}
+
+TEST( SweaterLibuv, FireAndForget_RunsWork )
+{
+    loop_guard runner;
+    ASSERT_TRUE( runner.ok );
+
+    psi::sweater::libuv::shop shop;
+    shop.bind_loop( runner.get() );
+
+    std::atomic<bool> done{ false };
+    EXPECT_TRUE( shop.fire_and_forget( [&]() noexcept { done.store( true, std::memory_order_release ); } ) );
+
+    auto const deadline{ std::chrono::steady_clock::now() + std::chrono::seconds{ 5 } };
+    while ( !done.load( std::memory_order_acquire ) && std::chrono::steady_clock::now() < deadline )
+    {
+        (void)uv_run( runner.get(), UV_RUN_ONCE );
+    }
+
+    EXPECT_TRUE( done.load( std::memory_order_acquire ) );
+    runner.drain();
+    EXPECT_EQ( psi::sweater::detail::in_flight_count(), 0u );
+}


### PR DESCRIPTION
## Summary
- Implement parallel `spread_the_sweat` in the libuv backend using `chunked_spread` + `uv_queue_work` (mirrors the Windows thread-pool strategy).
- Add `sweater_libuv_test` GTest target, built only when CMake finds libuv headers + library.
- Cover parallel spread, no-loop serial fallback, `fire_with_after`, and `fire_and_forget`.

## Test plan
- [x] Linux: `cmake -B build && cmake --build build --target sweater_libuv_test && ./build/test/sweater_libuv_test` (4/4 pass)
- [ ] macOS CI (if libuv present via Homebrew)
- [ ] Windows (skips libuv test when libuv not found)