### PR TITLE
feat(threading): reentrant-read rrw_mutex + recursive-read assertions on rw_mutex

### DIFF
--- a/include/psi/sweater/threading/posix/rw_mutex.hpp
+++ b/include/psi/sweater/threading/posix/rw_mutex.hpp
@@ -15,6 +15,8 @@
 //------------------------------------------------------------------------------
 #pragma once
 //------------------------------------------------------------------------------
+#include <psi/sweater/threading/read_recursion_registry.hpp>
+
 #include <boost/assert.hpp>
 
 #include <pthread.h>
@@ -57,14 +59,28 @@ public:
         return *this;
     }
 
-    void acquire_ro() noexcept { BOOST_VERIFY( pthread_rwlock_rdlock( &lock_ ) == 0 ); }
-    void release_ro() noexcept { BOOST_VERIFY( pthread_rwlock_unlock( &lock_ ) == 0 ); }
+    // Read side, instrumented (debug only) to catch recursive read-acquisition -- a
+    // documented hang on this non-recursive primitive (see read_recursion_registry.hpp).
+    // The raw os_acquire_ro/os_release_ro below are the un-instrumented OS calls, used
+    // by the reentrant rrw_mutex (which legitimately recurses and tracks its own depth).
+    void acquire_ro() noexcept { detail::on_ro_acquire( this ); os_acquire_ro(); }
+    void release_ro() noexcept { os_release_ro(); detail::on_ro_release( this ); }
 
     void acquire_rw() noexcept { BOOST_VERIFY( pthread_rwlock_wrlock( &lock_ ) == 0 ); }
-    void release_rw() noexcept { release_ro(); }
+    void release_rw() noexcept { os_release_ro(); } // raw: a write hold is not read-tracked
 
-    bool try_acquire_ro() noexcept { return pthread_rwlock_tryrdlock( &lock_ ) == 0; }
+    bool try_acquire_ro() noexcept { if ( !os_try_acquire_ro() ) { return false; } detail::on_ro_acquire( this ); return true; }
     bool try_acquire_rw() noexcept { return pthread_rwlock_trywrlock( &lock_ ) == 0; }
+
+protected:
+    // Raw, un-instrumented OS read lock/unlock (pthread treats unlock uniformly for the
+    // shared and exclusive sides). The reentrant rrw_mutex calls these on the outermost
+    // acquire / last release so its own recursion bookkeeping is the single source of
+    // truth (and the non-recursive recursion assert above never fires for it).
+    void os_acquire_ro() noexcept { BOOST_VERIFY( pthread_rwlock_rdlock   ( &lock_ ) == 0 ); }
+    void os_release_ro() noexcept { BOOST_VERIFY( pthread_rwlock_unlock   ( &lock_ ) == 0 ); }
+    bool os_try_acquire_ro() noexcept { return pthread_rwlock_tryrdlock( &lock_ ) == 0; }
+public:
 
     // debugging aid
     bool is_locked() const noexcept

--- a/include/psi/sweater/threading/read_recursion_registry.hpp
+++ b/include/psi/sweater/threading/read_recursion_registry.hpp
@@ -1,0 +1,145 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file read_recursion_registry.hpp
+/// ---------------------------------
+///
+/// (c) Copyright Domagoj Saric.
+///
+///  Use, modification and distribution are subject to the
+///  Boost Software License, Version 1.0. (See accompanying file
+///  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///
+///  See http://www.boost.org for most recent version.
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#pragma once
+//------------------------------------------------------------------------------
+#include <boost/assert.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple> // std::ignore
+#ifndef NDEBUG
+#include <vector>
+#endif
+
+// PSI_NOEXCEPT_EXCEPT_BADALLOC is normally supplied project-wide through the psi
+// build options (-D...): `noexcept` under a non-failing (overcommit-Full) allocator,
+// empty (may-throw) otherwise. The reentrant read acquire below allocates to track a
+// hold, so it carries that annotation. Provide the conservative may-throw fallback so
+// this header is usable in a standalone sweater build that does not pull in the psi
+// build options.
+#ifndef PSI_NOEXCEPT_EXCEPT_BADALLOC
+#   define PSI_NOEXCEPT_EXCEPT_BADALLOC
+#endif
+//------------------------------------------------------------------------------
+namespace psi::thrd_lite::detail
+{
+//------------------------------------------------------------------------------
+
+// One record of "this thread currently holds the read side of `mutex`, with recursion
+// depth `depth`". Keyed by object identity (void const *) so the registry stays fully
+// decoupled from rw_mutex.
+struct read_hold { void const * mutex; std::uint32_t depth; };
+
+// Per-thread record of the read locks the calling thread currently holds, with a
+// per-mutex recursion depth. The container is a template parameter (`HeldVec`, a
+// vector-like of read_hold) so callers pick the storage / allocation policy: a
+// dependency-light std::vector for standalone use, or an SBO small_vector to keep the
+// shallow common case allocation-free.
+//
+// UNBOUNDED on purpose: a single read operation can legitimately hold read locks on
+// many DISTINCT mutexes at once (e.g. a per-element lock over a user-supplied, uncapped
+// collection), so a fixed cap that overflowed would silently fall through to an
+// untracked acquire -- reintroducing the very recursion hang this exists to prevent,
+// and making release ambiguous (double-release of the OS lock => UB).
+template <class HeldVec>
+class read_recursion_registry
+{
+public:
+    // Returns true iff this is the FIRST hold on `m` by this thread, i.e. the caller
+    // must now take the OS read lock. Nested holds just bump the depth.
+    [[ nodiscard ]] bool enter( void const * const m ) PSI_NOEXCEPT_EXCEPT_BADALLOC
+    {
+        for ( auto & e : held_ )
+        {
+            if ( e.mutex == m ) { ++e.depth; return false; }
+        }
+        held_.emplace_back( m, std::uint32_t{ 1 } );
+        return true;
+    }
+
+    // Returns true iff this was the LAST hold on `m` by this thread, i.e. the caller
+    // must now drop the OS read lock.
+    [[ nodiscard ]] bool leave( void const * const m ) noexcept
+    {
+        for ( std::size_t i{ 0 }; i < held_.size(); ++i )
+        {
+            if ( held_[ i ].mutex == m )
+            {
+                if ( --held_[ i ].depth == 0 ) { held_[ i ] = held_.back(); held_.pop_back(); return true; }
+                return false;
+            }
+        }
+        // Unreachable for balanced same-thread use. Never drop an untracked OS lock
+        // (a double-release of the OS rwlock is UB); leak-safe no-op instead.
+        BOOST_ASSERT_MSG( false, "read_recursion_registry: release with no matching acquire on this thread" );
+        return false;
+    }
+
+    // try-acquire helper: bump iff `m` is already held by this thread (a reentrant try
+    // succeeds without touching the OS). Returns true iff it was held (and was bumped).
+    [[ nodiscard ]] bool bump_if_held( void const * const m ) noexcept
+    {
+        for ( auto & e : held_ )
+        {
+            if ( e.mutex == m ) { ++e.depth; return true; }
+        }
+        return false;
+    }
+
+    // Record a fresh (depth 1) hold after a successful OS try-acquire by this thread.
+    void note_first( void const * const m ) PSI_NOEXCEPT_EXCEPT_BADALLOC { held_.emplace_back( m, std::uint32_t{ 1 } ); }
+
+    [[ nodiscard ]] static read_recursion_registry & tls() noexcept
+    {
+        static thread_local read_recursion_registry instance;
+        return instance;
+    }
+
+private:
+    HeldVec held_;
+}; // class read_recursion_registry
+
+
+// ---------------------------------------------------------------------------
+// Debug-only recursion detection for the NON-recursive rw_mutex (see rw_mutex.hpp).
+// rw_mutex wraps a writer-preferring, non-recursive OS primitive: recursively taking
+// its read side while a writer is queued is a documented hang (POSIX
+// pthread_rwlock_rdlock "may deadlock"; Windows SRWLOCK "cannot be acquired
+// recursively"). These hooks make that misuse fail loudly at the first nested acquire
+// instead of parking at 0% CPU until a timeout. They are a complete no-op (and incur
+// no storage) in release builds.
+// ---------------------------------------------------------------------------
+#ifndef NDEBUG
+[[ gnu::cold ]] inline void on_ro_acquire( void const * const m )
+{
+    BOOST_ASSERT_MSG
+    (
+        read_recursion_registry<std::vector<read_hold>>::tls().enter( m ),
+        "recursive read-lock on a non-recursive psi::thrd_lite::rw_mutex -- use rrw_mutex for reentrant reads"
+    );
+}
+inline void on_ro_release( void const * const m ) noexcept
+{
+    std::ignore = read_recursion_registry<std::vector<read_hold>>::tls().leave( m );
+}
+#else
+inline void on_ro_acquire( void const * ) noexcept {}
+inline void on_ro_release( void const * ) noexcept {}
+#endif
+
+//------------------------------------------------------------------------------
+} // namespace psi::thrd_lite::detail
+//------------------------------------------------------------------------------

--- a/include/psi/sweater/threading/rrw_mutex.hpp
+++ b/include/psi/sweater/threading/rrw_mutex.hpp
@@ -1,0 +1,146 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// \file rrw_mutex.hpp
+/// -------------------
+///
+/// (c) Copyright Domagoj Saric.
+///
+///  Use, modification and distribution are subject to the
+///  Boost Software License, Version 1.0. (See accompanying file
+///  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+///
+///  See http://www.boost.org for most recent version.
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#pragma once
+//------------------------------------------------------------------------------
+#include "rw_mutex.hpp"
+#include "read_recursion_registry.hpp"
+
+#include <vector>
+//------------------------------------------------------------------------------
+namespace psi::thrd_lite
+{
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// rrw_mutex - a reentrant-READ extension of rw_mutex (recursive read, non-recursive
+// write).
+//
+// ---------------------------------------------------------------------------
+// The underlying-primitive limitation this works around
+// ---------------------------------------------------------------------------
+// rw_mutex wraps the platform shared/exclusive lock with default attributes:
+// writer-preferring and NON-recursive. Recursively taking the *read* side while a
+// writer is queued is documented as a hang on every backend:
+//
+//   - POSIX pthread_rwlock_t: a thread may hold multiple concurrent read locks, but
+//     if it requests another read lock "while a writer is waiting on the rwlock, the
+//     calling thread may deadlock" (writer preference wins over the nested reader).
+//     PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP is strictly writer-preferring.
+//       https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_rwlock_rdlock.html
+//       https://man7.org/linux/man-pages/man3/pthread_rwlockattr_setkind_np.3.html
+//   - Windows SRWLOCK: "SRW locks ... cannot be acquired recursively." Acquiring a
+//     shared lock a thread already holds (shared or exclusive) is undefined and
+//     deadlocks in practice.
+//       https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks
+//       https://learn.microsoft.com/en-us/windows/win32/api/synchronization/nf-synchronization-acquiresrwlockshared
+//
+// rw_mutex itself asserts (debug builds) on recursive read-acquisition so the misuse
+// fails loudly rather than hanging; rrw_mutex is the type to reach for when a design
+// legitimately needs nested reads.
+//
+// ---------------------------------------------------------------------------
+// How it works
+// ---------------------------------------------------------------------------
+// Only the OUTERMOST read acquire on a given mutex (per thread) touches the OS rwlock;
+// nested acquires and all but the last release just adjust this thread's depth counter.
+// The OS read lock is therefore held for the union of all live read holds on the thread
+// -- so relocation/pinning guarantees that depend on holding the read lock are preserved
+// -- while a nested acquire never re-enters the OS rdlock and so cannot block behind a
+// pending writer. The write side is inherited UNCHANGED (non-recursive): the hang is
+// specific to nested *read* acquisition behind a queued writer.
+//
+// ---------------------------------------------------------------------------
+// Why the recursion state is per-thread (not a counter member on the mutex)
+// ---------------------------------------------------------------------------
+// Reentrancy needs per-(thread, mutex) state: "does THIS thread already hold a read
+// lock on THIS mutex?". A read lock is multi-owner, so a single scalar count on the
+// mutex cannot answer it (count==2 might be one thread twice -> skip the OS re-acquire,
+// or two threads once each -> both must really hold). A single shared counter is also
+// racy (a second thread that bumps the count and proceeds before any thread's OS read
+// lock is actually held races a writer) and starvation-prone. A correct on-the-mutex
+// form -- a per-worker-slot depth array indexed by thread id -- would false-share the
+// hot lock word across workers and bloat every mutex instance. Per-thread storage has
+// neither cost: each thread's table is private memory. C++ has no per-object
+// thread_local, so the table is a thread_local keyed by mutex identity (see
+// read_recursion_registry), shared by all rrw_mutex instances of a given HeldVec type.
+//
+// Correctness rests on acquire/release being balanced on the SAME thread per mutex.
+//
+// ---------------------------------------------------------------------------
+// HeldVec
+// ---------------------------------------------------------------------------
+// The per-thread held-list container is a template parameter so callers pick the
+// storage / allocation policy without dragging a container dependency into sweater:
+// the default `rrw_mutex` alias uses std::vector (dependency-light, standalone), while
+// a caller that already has a small-vector can instantiate basic_rrw_mutex with an SBO
+// container to keep the shallow common case allocation-free.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+template <class HeldVec>
+class
+// Match the base's conditional trivial_abi: basic_rrw_mutex adds no data members, so it
+// is trivially relocatable exactly when rw_mutex is. This matters for callers that
+// bitwise-relocate objects embedding the mutex (trivial relocation is deduced from
+// trivial_abi).
+#if defined( _WIN32 ) || defined( PTHREAD_RWLOCK_INITIALIZER )
+    [[ clang::trivial_abi ]]
+#endif
+basic_rrw_mutex : public rw_mutex
+{
+public:
+    using rw_mutex::rw_mutex;
+
+    void acquire_ro() PSI_NOEXCEPT_EXCEPT_BADALLOC { if ( registry().enter( this ) ) { os_acquire_ro(); } }
+    void release_ro() noexcept                     { if ( registry().leave( this ) ) { os_release_ro(); } }
+
+    bool try_acquire_ro() PSI_NOEXCEPT_EXCEPT_BADALLOC
+    {
+        if ( registry().bump_if_held( this ) ) { return true; } // reentrant try: already held -> succeed
+        if ( os_try_acquire_ro() ) { registry().note_first( this ); return true; }
+        return false;
+    }
+
+    // std::shared_lock interface -- re-route through the reentrant overrides above (the
+    // base's non-virtual forwarders would statically bind to the base, non-reentrant,
+    // acquire_ro/release_ro).
+    void   lock_shared() PSI_NOEXCEPT_EXCEPT_BADALLOC { acquire_ro(); }
+    void unlock_shared() noexcept                     { release_ro(); }
+    bool try_lock_shared() PSI_NOEXCEPT_EXCEPT_BADALLOC { return try_acquire_ro(); }
+
+    // Write side (acquire_rw / release_rw / lock / unlock / try_lock / try_acquire_rw)
+    // is inherited UNCHANGED from rw_mutex: non-recursive, as before.
+
+private:
+    [[ nodiscard ]] static detail::read_recursion_registry<HeldVec> & registry() noexcept
+    {
+        return detail::read_recursion_registry<HeldVec>::tls();
+    }
+}; // class basic_rrw_mutex
+
+// Dependency-light default (std::vector storage) for standalone use; consumers that
+// already depend on a small-vector can supply an SBO container as HeldVec to keep the
+// shallow common case allocation-free.
+using rrw_mutex = basic_rrw_mutex< std::vector<detail::read_hold> >;
+
+// Reentrant read guard for the default rrw_mutex. (The write guard rw_lock works for
+// any basic_rrw_mutex unchanged, by upcast to rw_mutex.)
+using rro_lock = basic_ro_lock<rrw_mutex>;
+
+//------------------------------------------------------------------------------
+} // namespace psi::thrd_lite
+//------------------------------------------------------------------------------

--- a/include/psi/sweater/threading/rw_mutex.hpp
+++ b/include/psi/sweater/threading/rw_mutex.hpp
@@ -28,24 +28,33 @@ namespace psi::thrd_lite
 {
 //------------------------------------------------------------------------------
 
-class [[ clang::trivial_abi ]] ro_lock
+// RAII read guard, templated on the mutex type so a single definition serves both the
+// non-recursive rw_mutex (`ro_lock`) and the reentrant rrw_mutex (`rro_lock`, see
+// rrw_mutex.hpp). It stores Mutex* (not rw_mutex*) so acquire_ro/release_ro dispatch to
+// the most-derived overrides -- a base rw_mutex* would slice past rrw_mutex's reentrant
+// ones. The ctor is annotated may-throw-on-bad-alloc because the reentrant acquire_ro
+// allocates to track the hold (it is plain noexcept for the non-recursive rw_mutex).
+template <class Mutex>
+class [[ clang::trivial_abi ]] basic_ro_lock
 {
 public:
-    constexpr ro_lock() noexcept = default;
-    ro_lock( rw_mutex & mutex ) noexcept : p_mutex_{ &mutex } {                 p_mutex_->acquire_ro(); }
-   ~ro_lock(                  ) noexcept                      { if ( p_mutex_ ) p_mutex_->release_ro(); }
-    ro_lock( ro_lock const &  ) = delete;
-    ro_lock( ro_lock && other ) noexcept : p_mutex_{ std::exchange( other.p_mutex_, nullptr ) } {}
+    constexpr basic_ro_lock() noexcept = default;
+    basic_ro_lock( Mutex & mutex ) PSI_NOEXCEPT_EXCEPT_BADALLOC : p_mutex_{ &mutex } {                 p_mutex_->acquire_ro(); }
+   ~basic_ro_lock(              ) noexcept                                          { if ( p_mutex_ ) p_mutex_->release_ro(); }
+    basic_ro_lock( basic_ro_lock const &  ) = delete;
+    basic_ro_lock( basic_ro_lock && other ) noexcept : p_mutex_{ std::exchange( other.p_mutex_, nullptr ) } {}
 
-    ro_lock & operator=( ro_lock && other ) noexcept
+    basic_ro_lock & operator=( basic_ro_lock && other ) noexcept
     {
         std::destroy_at( this );
         return *std::construct_at( this, std::move( other ) );
     }
 
 private:
-    rw_mutex * p_mutex_{};
-}; // class ro_lock
+    Mutex * p_mutex_{};
+}; // class basic_ro_lock
+
+using ro_lock = basic_ro_lock<rw_mutex>;
 
 
 class [[ clang::trivial_abi ]] rw_lock

--- a/include/psi/sweater/threading/windows/rw_mutex.hpp
+++ b/include/psi/sweater/threading/windows/rw_mutex.hpp
@@ -15,6 +15,8 @@
 //------------------------------------------------------------------------------
 #pragma once
 //------------------------------------------------------------------------------
+#include <psi/sweater/threading/read_recursion_registry.hpp>
+
 #include <boost/assert.hpp>
 #include <windows.h>
 //------------------------------------------------------------------------------
@@ -41,14 +43,28 @@ public:
         return *this;
     }
 
-    void acquire_ro() noexcept { verify_deadlock(); ::AcquireSRWLockShared( &lock_ ); }
-    void release_ro() noexcept {                    ::ReleaseSRWLockShared( &lock_ ); }
+    // Read side, instrumented (debug only): verify_deadlock() catches read-while-holding
+    // the exclusive lock, on_ro_acquire() catches recursive read-acquisition -- both are
+    // documented hangs on this non-recursive primitive (see read_recursion_registry.hpp).
+    // The raw os_acquire_ro/os_release_ro below are the un-instrumented OS calls, used by
+    // the reentrant rrw_mutex (which legitimately recurses and tracks its own depth).
+    void acquire_ro() noexcept { verify_deadlock(); detail::on_ro_acquire( this ); os_acquire_ro(); }
+    void release_ro() noexcept { os_release_ro(); detail::on_ro_release( this ); }
 
     void acquire_rw() noexcept { verify_deadlock(); ::AcquireSRWLockExclusive( &lock_ ); BOOST_ASSERT( active_writer_ = ::GetCurrentThreadId() ); }
     void release_rw() noexcept {                    ::ReleaseSRWLockExclusive( &lock_ ); BOOST_ASSERT( !( active_writer_ = 0 ) ); }
 
-    bool try_acquire_ro() noexcept { verify_deadlock(); return ::TryAcquireSRWLockShared   ( &lock_ ) != false; }
+    bool try_acquire_ro() noexcept { verify_deadlock(); if ( !os_try_acquire_ro() ) { return false; } detail::on_ro_acquire( this ); return true; }
     bool try_acquire_rw() noexcept { verify_deadlock(); return ::TryAcquireSRWLockExclusive( &lock_ ) != false; }
+
+protected:
+    // Raw, un-instrumented OS shared lock/unlock. The reentrant rrw_mutex calls these on
+    // the outermost acquire / last release so its own recursion bookkeeping is the single
+    // source of truth (and the non-recursive recursion assert above never fires for it).
+    void os_acquire_ro() noexcept { ::AcquireSRWLockShared( &lock_ ); }
+    void os_release_ro() noexcept { ::ReleaseSRWLockShared( &lock_ ); }
+    bool os_try_acquire_ro() noexcept { return ::TryAcquireSRWLockShared( &lock_ ) != false; }
+public:
 
     [[ gnu::pure ]] bool locked() const noexcept { return lock_.Ptr != nullptr; }
 


### PR DESCRIPTION
## Summary

Adds a reentrant-**read** mutex (`rrw_mutex`) alongside the existing `rw_mutex`, and makes
`rw_mutex` assert loudly (debug builds) when a thread recursively takes its read side — the
documented hang turned into an early, explicit failure. The two share as much as possible: one
per-thread recursion registry, one templated read guard, and the *same* concrete write guard.

## Why

`rw_mutex` wraps the platform shared/exclusive lock with default attributes: **writer-preferring
and non-recursive**. A thread that already holds the read side and asks for it again *while a
writer is queued* deadlocks — documented on every backend:

- POSIX `pthread_rwlock_rdlock`: requesting a read lock "while a writer is waiting on the rwlock,
  the calling thread may deadlock". (`PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP` is
  strictly writer-preferring.)
- Windows `SRWLOCK`: "SRW locks … cannot be acquired recursively." Recursively acquiring a held
  shared lock is undefined and deadlocks in practice.

Some designs legitimately nest read acquisitions (a long-lived read-pinned reference re-entered
while live, with reads running concurrently with a writer). For those, `rw_mutex` is a footgun;
`rrw_mutex` is the type to reach for.

## What's added / changed

- **`detail::read_recursion_registry<HeldVec>`** (`read_recursion_registry.hpp`) — a per-thread,
  per-mutex read-recursion depth table keyed by object identity. The container is a **template
  parameter** so callers pick the storage/allocation policy without dragging a container
  dependency into sweater. Unbounded by design (one read op can hold read locks on many distinct
  mutexes at once, so a fixed cap that overflowed would silently fall through to an untracked
  acquire).
- **`rw_mutex`** — refactored to expose `protected os_acquire_ro / os_release_ro /
  os_try_acquire_ro` (the raw OS calls). The public read API now runs a **debug-only** recursion
  check through the shared registry: a recursive read-acquire fails the assert with "use
  rrw_mutex" instead of hanging. **Zero-cost and byte-identical in release** (`NDEBUG`); public
  API and layout unchanged.
- **`basic_rrw_mutex<HeldVec>`** (`rrw_mutex.hpp`) — derives from `rw_mutex`; the outermost read
  acquire (per thread) takes the OS lock, nested acquires/releases only adjust the depth. The
  write side is inherited **unchanged** (non-recursive). Adds no data members → identical layout,
  same conditional `trivial_abi`. Defaults: `rrw_mutex = basic_rrw_mutex<std::vector<read_hold>>`
  (dependency-light, standalone) and `rro_lock = basic_ro_lock<rrw_mutex>`.
- **Guards** — the read guard is now `basic_ro_lock<Mutex>` (templated on the mutex type so one
  definition serves both `rw_mutex` and `rrw_mutex`); `ro_lock = basic_ro_lock<rw_mutex>`. The
  **write guard `rw_lock` is unchanged** — it already works for `rrw_mutex` by upcast, since the
  write side is inherited verbatim (no override to slice).

## Design notes

- **Per-thread, not on-mutex.** Reentrancy needs per-(thread, mutex) state; a read lock is
  multi-owner so a scalar count on the mutex can't answer "does *this* thread already hold it?"
  (and is racy / starvation-prone). A per-worker-slot array on the mutex would false-share the hot
  lock word and bloat every instance. A `thread_local` keyed by mutex identity has neither cost.
- **`HeldVec` template parameter.** Keeps sweater dependency-light: the default uses `std::vector`;
  a consumer that already has a small-vector can supply an SBO container to keep the shallow common
  case allocation-free.
- **Standalone build.** The reentrant acquire allocates to track a hold, so it carries
  `PSI_NOEXCEPT_EXCEPT_BADALLOC` (propagate `bad_alloc`); a header-local `#ifndef` fallback (empty
  = may-throw) keeps the headers usable without the psi build options.

## Compatibility

`ro_lock` / `rw_lock` callers are unchanged. `rw_mutex`'s public API is unchanged — only internal
factoring plus a debug-only recursion assert. Correctness rests on acquire/release being balanced
on the same thread per mutex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
